### PR TITLE
Fixed contentScrollView frame

### DIFF
--- a/SHTabScrollController/SHTabScrollController.m
+++ b/SHTabScrollController/SHTabScrollController.m
@@ -166,8 +166,8 @@
 }
 
 - (void)viewWillLayoutSubviews {
-    self.contentScrollView.frame = CGRectMake(0, CGRectGetMaxY(self.tabBottomView.frame), SCREEN_WIDTH, self.view.bounds.size.height - self.tabButtonHeight);
-    self.contentScrollView.contentSize = CGSizeMake(SCREEN_WIDTH * self.controllersArray.count, self.view.bounds.size.height - self.tabButtonHeight);
+    self.contentScrollView.frame = CGRectMake(0, CGRectGetMaxY(self.tabBottomView.frame), SCREEN_WIDTH, self.view.bounds.size.height - _tabButtonHeight - _tabBottomViewHeight);
+    self.contentScrollView.contentSize = CGSizeMake(SCREEN_WIDTH * self.controllersArray.count, self.view.bounds.size.height - _tabButtonHeight - _tabBottomViewHeight);
     self.backgroundView.frame = self.view.bounds;
     self.contentBackgroundView.frame = CGRectMake(0, CGRectGetMaxY(self.tabBottomView.frame), SCREEN_WIDTH, self.view.bounds.size.height - self.tabButtonHeight);
     self.tabButtonBackgroundView.frame = CGRectMake(0, 0, SCREEN_WIDTH, CGRectGetMaxY(self.tabBottomView.frame));


### PR DESCRIPTION
修复了计算  contentScrollView frame 时漏减 tabBottomViewHeight 的问题。
此 BUG 会导致设置 tabBottomViewHeight 后，contentScrollView 的底部无法点击。

注：由于按钮行下方先是 tabBottomView 再是 contentScrollView，计算时应考虑从 self.view.bounds.size.height 分别减去它们。